### PR TITLE
Fix parsing of whitespace

### DIFF
--- a/fdt.cc
+++ b/fdt.cc
@@ -861,6 +861,7 @@ node::node(text_input_buffer &input,
 		}
 		input.next_token();
 	}
+	input.next_token();
 	input.consume(';');
 }
 

--- a/fdt.cc
+++ b/fdt.cc
@@ -1335,8 +1335,8 @@ device_tree::parse_file(text_input_buffer &input,
 		input.next_token();
 		input.consume(';');
 		reservations.push_back(reservation(start, len));
+		input.next_token();
 	}
-	input.next_token();
 	while (valid && !input.finished())
 	{
 		node_ptr n;


### PR DESCRIPTION
This adds/moves calls to `input.next_token()` to help parse the Linux dts files.