### PR TITLE
fdt: Expect strchr() to return a const char*.

### DIFF
--- a/fdt.cc
+++ b/fdt.cc
@@ -1635,7 +1635,7 @@ device_tree::parse_dts(const string &fn, FILE *depfile)
 
 bool device_tree::parse_define(const char *def)
 {
-	char *val = strchr(def, '=');
+	const char *val = strchr(def, '=');
 	if (!val)
 	{
 		if (strlen(def) != 0)


### PR DESCRIPTION
In C, `strchr(3)` returns a `char*`, whereas C++ defines two overloads:
* `const char *strchr(const char*, int)`
* `char *strchr(char*, int)`

Building fdt.cc with libc++ 3.9.0 was failing because [libc++ r260377](http://llvm.org/viewvc/llvm-project?view=revision&revision=260337)
added the first overload to string.h, leading to failures such as:

    fdt.cc:1638:8: error: cannot initialize a variable of type 'char *' with an rvalue of type 'const char *'

Just define `val` as a `const char*` to fix it.