### PR TITLE
fix build when NDEBUG is defined

### DIFF
--- a/input_buffer.cc
+++ b/input_buffer.cc
@@ -32,6 +32,7 @@
 
 #include "input_buffer.hh"
 #include <ctype.h>
+#include <errno.h>
 #include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -545,7 +546,8 @@ struct binary_operator : public binary_operator_base
 	 * Constructor.  Takes the name of the operator as an argument, for
 	 * debugging.  Only stores it in debug mode.
 	 */
-	binary_operator(source_location l, const char *) : expression(l) {}
+	binary_operator(source_location l, const char *) :
+		binary_operator_base(l) {}
 #else
 	const char *opName;
 	binary_operator(source_location l, const char *o) :


### PR DESCRIPTION
Initialize correct parent in binary_operator's constructor.

Include <errno.h> explicitly. Without NDEBUG, errno was declared as
a side effect of including <iostream>.

Obtained from FreeBSD r313709 by dim@FreeBSD.org.