### PR TITLE
Add missing "typename" in divmod's  "using" of binary_operator_base::result

### DIFF
--- a/input_buffer.cc
+++ b/input_buffer.cc
@@ -654,7 +654,7 @@ template<typename T>
 struct divmod : public binary_operator<5, T>
 {
 	using binary_operator<5, T>::binary_operator;
-	using binary_operator_base::result;
+	using typename binary_operator_base::result;
 	result operator()() override
 	{
 		result r = (*binary_operator_base::rhs)();


### PR DESCRIPTION
This is all in input_buffer.cc .