### PR TITLE
version output fix

### DIFF
--- a/dtc.cc
+++ b/dtc.cc
@@ -51,14 +51,17 @@ using std::string;
  * The current major version of the tool.
  */
 int version_major = 0;
+int version_major_compatible = 1;
 /**
  * The current minor version of the tool.
  */
 int version_minor = 5;
+int version_minor_compatible = 4;
 /**
  * The current patch level of the tool.
  */
 int version_patch = 0;
+int version_patch_compatible = 0;
 
 static void usage(const string &argv0)
 {
@@ -77,8 +80,10 @@ static void usage(const string &argv0)
  */
 static void version(const char* progname)
 {
-	fprintf(stderr, "Version: %s %d.%d.%d\n", progname, version_major,
-			version_minor, version_patch);
+	fprintf(stdout, "Version: %s %d.%d.%d gnu compatible %d.%d.%d\n", progname,
+		version_major, version_minor, version_patch,
+		version_major_compatible, version_minor_compatible,
+		version_patch_compatible);
 }
 
 using fdt::device_tree;


### PR DESCRIPTION
Version output should be on stdout as most of the tools that parse this
information don't play with redirection.
Also add a 'gnu compatible' version (For now matching on 1.4.0)
U-Boot check the version for some target so we need some compliance on this.

Signed-off-by: Emmanuel Vadot <manu@freebsd.org>