### PR TITLE
Fix resolve_cross_reference

### DIFF
--- a/Tests/cross_reference.dts
+++ b/Tests/cross_reference.dts
@@ -1,0 +1,12 @@
+/dts-v1/;
+
+/{
+	soc@deadbeef {
+		baz: baz@0000 {
+		};
+	};
+
+	foo {
+		cross = &baz;
+	};
+};

--- a/Tests/cross_reference.dts.expected
+++ b/Tests/cross_reference.dts.expected
@@ -1,0 +1,15 @@
+/dts-v1/;
+
+/  {
+
+	soc@deadbeef {
+
+		baz@0000 {
+
+		};
+	};
+	foo {
+
+		cross = "/soc@deadbeef/baz@0000";
+	};
+};

--- a/fdt.cc
+++ b/fdt.cc
@@ -1224,9 +1224,9 @@ device_tree::resolve_cross_references()
 				{
 					pv->byte_data.push_back('@');
 					push_string(pv->byte_data, p->second);
-					pv->byte_data.push_back(0);
 				}
 			}
+			pv->byte_data.push_back(0);
 		}
 	}
 	std::unordered_map<property_value*, fixup&> phandle_set;


### PR DESCRIPTION
The null char need to be at the end.

Fix issue #20

Signed-off-by: Emmanuel Vadot <manu@freebsd.org>