### PR TITLE
Add/amend tests for proper /__local_fixups__

### DIFF
--- a/Tests/localfixups_multinode.at.dts
+++ b/Tests/localfixups_multinode.at.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/{
+   quxnode {
+      qux = <&BAZ>;
+   };
+   quuxnode {
+      quux = <1 2 3 4 &FOO>;
+   };
+   FOO: foo { };
+   BAZ: baz { };
+};

--- a/Tests/localfixups_multinode.at.dts.expected
+++ b/Tests/localfixups_multinode.at.dts.expected
@@ -8,7 +8,11 @@
 	};
 	quuxnode {
 
-		quux = <0x1 0x2 0x3 0x4 0xdeadbeef>;
+		quux = <0x1 0x2 0x3 0x4 0x2>;
+	};
+	foo {
+
+		phandle = <0x2>;
 	};
 	baz {
 
@@ -16,16 +20,18 @@
 	};
 	__symbols__ {
 
+		FOO = "/foo";
 		BAZ = "/baz";
-	};
-	__fixups__ {
-
-		FOO = "/quuxnode:quux:16";
 	};
 	__local_fixups__ {
 
 		quxnode {
-			quz = <0x0>;
+
+			qux = <0x0>;
+		};
+		quuxnode {
+
+			quux = <0x10>;
 		};
 	};
 };

--- a/Tests/localfixups_multioffset.at.dts
+++ b/Tests/localfixups_multioffset.at.dts
@@ -1,0 +1,10 @@
+/dts-v1/;
+/plugin/;
+
+/{
+   quxnode {
+      qux = <&BAZ 0x01 0x03 &FOO>;
+   };
+   FOO: foo { };
+   BAZ: baz { };
+};

--- a/Tests/localfixups_multioffset.at.dts.expected
+++ b/Tests/localfixups_multioffset.at.dts.expected
@@ -4,11 +4,11 @@
 
 	quxnode {
 
-		qux = <0x1>;
+		qux = <0x1 0x1 0x3 0x2>;
 	};
-	quuxnode {
+	foo {
 
-		quux = <0x1 0x2 0x3 0x4 0xdeadbeef>;
+		phandle = <0x2>;
 	};
 	baz {
 
@@ -16,16 +16,14 @@
 	};
 	__symbols__ {
 
+		FOO = "/foo";
 		BAZ = "/baz";
-	};
-	__fixups__ {
-
-		FOO = "/quuxnode:quux:16";
 	};
 	__local_fixups__ {
 
 		quxnode {
-			quz = <0x0>;
+
+			qux = <0x0 0xc>;
 		};
 	};
 };

--- a/Tests/localfixups_multiprop.at.dts
+++ b/Tests/localfixups_multiprop.at.dts
@@ -1,0 +1,11 @@
+/dts-v1/;
+/plugin/;
+
+/{
+   quxnode {
+      qux = <&BAZ>;
+      quux = <&FOO>;
+   };
+   FOO: foo { };
+   BAZ: baz { };
+};

--- a/Tests/localfixups_multiprop.at.dts.expected
+++ b/Tests/localfixups_multiprop.at.dts.expected
@@ -5,10 +5,11 @@
 	quxnode {
 
 		qux = <0x1>;
+		quux = <0x2>;
 	};
-	quuxnode {
+	foo {
 
-		quux = <0x1 0x2 0x3 0x4 0xdeadbeef>;
+		phandle = <0x2>;
 	};
 	baz {
 
@@ -16,16 +17,15 @@
 	};
 	__symbols__ {
 
+		FOO = "/foo";
 		BAZ = "/baz";
-	};
-	__fixups__ {
-
-		FOO = "/quuxnode:quux:16";
 	};
 	__local_fixups__ {
 
 		quxnode {
-			quz = <0x0>;
+
+			qux = <0x0>;
+			quux = <0x0>;
 		};
 	};
 };


### PR DESCRIPTION
The eventually agreed-upon `/__local_fixups__` output differs from what we currently
write, though how we write it seems logical/consistent. Fix the resolve test
case to match how it *should* be, and add three more test cases for more complex
scenarios to make sure we're generating is as expected by libfdt and other
consumers of overlays.

These test cases go along with Issue #27 -- they were generated by compiling the .dts to .dtbo with GPL dtc(1) and then converting back to .dts with BSD dtc(1), and match what I expect to see based on libfdt's `/__local_fixups__` handling code [1].

[1] https://github.com/dgibson/dtc/blob/master/libfdt/fdt_overlay.c#L218