### PR TITLE
Syntactic sugar for overlays

### DIFF
--- a/Tests/overlay_sugar.at.dts
+++ b/Tests/overlay_sugar.at.dts
@@ -1,0 +1,26 @@
+/dts-v1/;
+/plugin/;
+
+&foo {
+	foo,status = "okay";
+};
+
+&bar {
+	bar,status = "okay";
+};
+
+/ {
+	fragment@0 {
+		target = <&qux>;
+		__overlay__ {
+			qux,status = "okay";
+		};
+	};
+};
+
+&baz {
+	baz,status = "okay";
+	foobar: foobar {
+		foobar,status = "okay";
+	};
+};

--- a/Tests/overlay_sugar.at.dts.expected
+++ b/Tests/overlay_sugar.at.dts.expected
@@ -1,0 +1,53 @@
+/dts-v1/;
+
+/  {
+
+	fragment@0 {
+
+		target = <0xdeadbeef>;
+		__overlay__ {
+
+			foo,status = "okay";
+		};
+	};
+	fragment@1 {
+
+		target = <0xdeadbeef>;
+		__overlay__ {
+
+			bar,status = "okay";
+		};
+	};
+	fragment@2 {
+
+		target = <0xdeadbeef>;
+		__overlay__ {
+
+			qux,status = "okay";
+		};
+	};
+	fragment@3 {
+
+		target = <0xdeadbeef>;
+		__overlay__ {
+
+			baz,status = "okay";
+			foobar {
+
+				foobar,status = "okay";
+				phandle = <0x1>;
+			};
+		};
+	};
+	__symbols__ {
+
+		foobar = "/fragment@3/__overlay__/foobar";
+	};
+	__fixups__ {
+
+		foo = "/fragment@0:target:0";
+		bar = "/fragment@1:target:0";
+		qux = "/fragment@2:target:0";
+		baz = "/fragment@3:target:0";
+	};
+};

--- a/fdt.cc
+++ b/fdt.cc
@@ -1022,7 +1022,7 @@ node::get_property(const string &key)
 }
 
 void
-node::merge_node(node_ptr other)
+node::merge_node(node_ptr &other)
 {
 	for (auto &l : other->labels)
 	{
@@ -1057,7 +1057,7 @@ node::merge_node(node_ptr other)
 		{
 			if (i->name == c->name && i->unit_address == c->unit_address)
 			{
-				i->merge_node(std::move(c));
+				i->merge_node(c);
 				found = true;
 				break;
 			}
@@ -1712,7 +1712,7 @@ device_tree::create_fragment_wrapper(node_ptr &node, int &fragnum)
 
 	node_ptr fragment = node::create_special_node(fragment_address, symbols);
 
-	wrapper->merge_node(std::move(node));
+	wrapper->merge_node(node);
 	fragment->add_child(std::move(wrapper));
 	newroot->add_child(std::move(fragment));
 	return newroot;
@@ -1811,7 +1811,7 @@ device_tree::parse_dts(const string &fn, FILE *depfile)
 						// fragnum before we merge it
 						reassign_fragment_numbers(node, fragnum);
 					}
-					root->merge_node(std::move(node));
+					root->merge_node(node);
 				}
 				else
 				{
@@ -1825,7 +1825,8 @@ device_tree::parse_dts(const string &fn, FILE *depfile)
 					{
 						if (is_plugin)
 						{
-							root->merge_node(create_fragment_wrapper(node, fragnum));
+							auto fragment = create_fragment_wrapper(node, fragnum);
+							root->merge_node(fragment);
 						}
 						else
 						{
@@ -1834,7 +1835,7 @@ device_tree::parse_dts(const string &fn, FILE *depfile)
 					}
 					else
 					{
-						existing->second->merge_node(std::move(node));
+						existing->second->merge_node(node);
 					}
 				}
 			}

--- a/fdt.cc
+++ b/fdt.cc
@@ -1800,7 +1800,14 @@ device_tree::parse_dts(const string &fn, FILE *depfile)
 					}
 					if (existing == node_names.end())
 					{
-						fprintf(stderr, "Unable to merge node: %s\n", name.c_str());
+						if (is_plugin)
+						{
+							root->merge_node(create_fragment_wrapper(node, fragnum));
+						}
+						else
+						{
+							fprintf(stderr, "Unable to merge node: %s\n", name.c_str());
+						}
 					}
 					else
 					{

--- a/fdt.cc
+++ b/fdt.cc
@@ -1814,6 +1814,12 @@ device_tree::parse_dts(const string &fn, FILE *depfile)
 				string name = node->name;
 				if (name == string())
 				{
+					if (is_plugin)
+					{
+						// Re-assign any fragment numbers based on a delta of
+						// fragnum before we merge it
+						reassign_fragment_numbers(node, fragnum);
+					}
 					root->merge_node(std::move(node));
 				}
 				else

--- a/fdt.cc
+++ b/fdt.cc
@@ -1741,7 +1741,7 @@ device_tree::reassign_fragment_numbers(node_ptr &node, int &delta)
 
 	for (auto &c : node->child_nodes())
 	{
-		int current_address = std::stoi(c->unit_address, NULL, 16);
+		int current_address = std::stoi(c->unit_address, nullptr, 16);
 		std::ostringstream new_address;
 		current_address += delta;
 		// It's possible that we hopped more than one somewhere, so just reset

--- a/fdt.cc
+++ b/fdt.cc
@@ -1736,6 +1736,32 @@ device_tree::generate_root(node_ptr &node, int &fragnum)
 }
 
 void
+device_tree::reassign_fragment_numbers(node_ptr &node, int &delta)
+{
+
+	for (auto &c : node->child_nodes())
+	{
+		int current_address;
+		try
+		{
+			current_address = std::stoi(c->unit_address);
+		}
+		catch (std::exception &exc)
+		{
+			// Just default to 0; we'll add our delta and increment it, and all
+			// will be fine.  Fragment addresses aren't necessarily supposed to
+			// mean anything, we just strive to maintain some sanity.
+			current_address = 0;
+		}
+		current_address += delta;
+		// It's possible that we hopped more than one somewhere, so just reset
+		// delta to the next in sequence.
+		delta = current_address + 1;
+		c->unit_address = std::to_string(current_address);
+	}
+}
+
+void
 device_tree::parse_dts(const string &fn, FILE *depfile)
 {
 	auto in = input_buffer::buffer_for_file(fn);

--- a/fdt.hh
+++ b/fdt.hh
@@ -620,7 +620,7 @@ class node
 	 * Merges a node into this one.  Any properties present in both are
 	 * overridden, any properties present in only one are preserved.
 	 */
-	void merge_node(node_ptr other);
+	void merge_node(node_ptr &other);
 	/**
 	 * Write this node to the specified output.  Although nodes do not
 	 * refer to a string table directly, their properties do.  The string

--- a/fdt.hh
+++ b/fdt.hh
@@ -882,6 +882,14 @@ class device_tree
 	 * fragnumas its fragment number, and fragment number will be incremented.
 	 */
 	node_ptr create_fragment_wrapper(node_ptr &node, int &fragnum);
+	/**
+	 * Generate a root node from the node passed in.  This is sensitive to
+	 * whether we're in a plugin context or not, so that if we're in a plugin we
+	 * can circumvent any errors that might normally arise from a non-/ root.
+	 * fragnum will be assigned to any fragment wrapper generated as a result
+	 * of the call, and fragnum will be incremented.
+	 */
+	node_ptr generate_root(node_ptr &node, int &fragnum);
 	/*
 	 * Constructs a device tree from the specified file name, referring to
 	 * a file that contains device tree source.

--- a/fdt.hh
+++ b/fdt.hh
@@ -876,6 +876,13 @@ class device_tree
 	 */
 	void parse_dtb(const std::string &fn, FILE *depfile);
 	/**
+	 * Construct a fragment wrapper around node.  This will assume that node's
+	 * name may be used as the target of the fragment, and the contents are to
+	 * be wrapped in an __overlay__ node.  The fragment wrapper will be assigned
+	 * fragnumas its fragment number, and fragment number will be incremented.
+	 */
+	node_ptr create_fragment_wrapper(node_ptr &node, int &fragnum);
+	/*
 	 * Constructs a device tree from the specified file name, referring to
 	 * a file that contains device tree source.
 	 */

--- a/fdt.hh
+++ b/fdt.hh
@@ -890,6 +890,11 @@ class device_tree
 	 * of the call, and fragnum will be incremented.
 	 */
 	node_ptr generate_root(node_ptr &node, int &fragnum);
+	/**
+	 * Reassign any fragment numbers from this new node, based on the given
+	 * delta.
+	 */
+	void reassign_fragment_numbers(node_ptr &node, int &delta);
 	/*
 	 * Constructs a device tree from the specified file name, referring to
 	 * a file that contains device tree source.


### PR DESCRIPTION
This syntactic sugar might be best explained by the test, but it generally exists to transform:

```
&foo {
    prop = "value";
};
```
into
```
/ {
    fragment@0 {
        target = <&foo>;
        __overlay__ {
            prop = "value";
        };
    };
};
```

It is meant to take a little bit of edge off of creating overlays, making it more natural to other .dts concepts.

I note here that GPL dtc(1) currently has some weird behavior if you mix traditional overlay fragments with this new syntax, as I've done in this test. Their weird behavior ranges from rejecting duplicate node names (OK) to silently merging the nodes and keeping one of the target properties.

I'll take this behaviors up with them, but I think how I've implemented this here is a safe bet, given that I don't think it will be valid to try and merge one of our ad-hoc fragments with an explicitly defined fragment, even if it's targeting the same node by phandle.