### PR TITLE
Enable tests automatically for debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,15 @@ set(dtc_CXX_SRCS
 add_executable(dtc ${dtc_CXX_SRCS})
 
 set_property(TARGET dtc PROPERTY CXX_STANDARD 11)
+set(ENABLE_TESTS_DEFAULT FALSE)
 
-option(ENABLE_TESTS "Enable the tests")
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+	set(ENABLE_TESTS_DEFAULT TRUE)
+endif()
 
-if(ENABLE_TESTS OR CMAKE_BUILD_TYPE MATCHES Debug)
+option(ENABLE_TESTS "Enable the tests" ${ENABLE_TESTS_DEFAULT})
+
+if(ENABLE_TESTS)
 	enable_testing()
 	add_subdirectory("Tests")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set_property(TARGET dtc PROPERTY CXX_STANDARD 11)
 
 option(ENABLE_TESTS "Enable the tests")
 
-if(ENABLE_TESTS)
+if(ENABLE_TESTS OR CMAKE_BUILD_TYPE MATCHES Debug)
 	enable_testing()
 	add_subdirectory("Tests")
 endif()


### PR DESCRIPTION
This has made development much better on my end, only having to remember to enable debug to include the tests. I've made it ignore ENABLE_TESTS since I've not yet found a reason that I'd want a debug build with tests explicitly turned off.