### PR TITLE
Fix some regressions caused by recent additions

### DIFF
--- a/Tests/testexpected.sh
+++ b/Tests/testexpected.sh
@@ -20,11 +20,10 @@ if [ `basename ${2}` == "${DOCOPY_TEST}" ] ; then
 fi
 
 "$1" $AT -I dts -O dts "$2" | diff "${2}.expected" -
-
-if [ $? -ne 0 ]; then
-	exit 1
-fi
+_exit=$?
 
 if [ `basename ${2}` == "${DOCOPY_TEST}" ] ; then
 	rm ${DOCOPY_TO}
 fi
+
+exit $_exit

--- a/Tests/testexpected.sh
+++ b/Tests/testexpected.sh
@@ -21,6 +21,10 @@ fi
 
 "$1" $AT -I dts -O dts "$2" | diff "${2}.expected" -
 
+if [ $? -ne 0 ]; then
+	exit 1
+fi
+
 if [ `basename ${2}` == "${DOCOPY_TEST}" ] ; then
 	rm ${DOCOPY_TO}
 fi

--- a/fdt.cc
+++ b/fdt.cc
@@ -1741,14 +1741,17 @@ device_tree::reassign_fragment_numbers(node_ptr &node, int &delta)
 
 	for (auto &c : node->child_nodes())
 	{
-		int current_address = std::stoi(c->unit_address, nullptr, 16);
-		std::ostringstream new_address;
-		current_address += delta;
-		// It's possible that we hopped more than one somewhere, so just reset
-		// delta to the next in sequence.
-		delta = current_address + 1;
-		new_address << std::hex << current_address;
-		c->unit_address = new_address.str();
+		if (c->name == std::string("fragment"))
+		{
+			int current_address = std::stoi(c->unit_address, nullptr, 16);
+			std::ostringstream new_address;
+			current_address += delta;
+			// It's possible that we hopped more than one somewhere, so just reset
+			// delta to the next in sequence.
+			delta = current_address + 1;
+			new_address << std::hex << current_address;
+			c->unit_address = new_address.str();
+		}
 	}
 }
 

--- a/fdt.hh
+++ b/fdt.hh
@@ -869,7 +869,7 @@ class device_tree
 	 */
 	device_tree() : phandle_node_name(EPAPR), valid(true),
 		boot_cpu(0), spare_reserve_map_entries(0),
-		minimum_blob_size(0), blob_padding(0) {}
+		minimum_blob_size(0), blob_padding(0), is_plugin(false) {}
 	/**
 	 * Constructs a device tree from the specified file name, referring to
 	 * a file that contains a device tree blob.


### PR DESCRIPTION
 - Properly initialize is_plugin; some non-/plugin/ dtb were getting generated with /__fixups__ and /__local_fixups__
 - Don't try and re-assign unit addresses on non-fragment nodes
 - Explicitly check exit code of dtc|diff now that it's no longer the exit code of the script