### PR TITLE
Fix warnings when WARNS=6, remove WARNS override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@ PROG_CXX=dtc
 SRCS=	dtc.cc input_buffer.cc string.cc dtb.cc fdt.cc checking.cc
 MAN=	dtc.1
 
-WARNS?=	3
-
 CXXFLAGS+=	-std=c++11 -fno-rtti -fno-exceptions
 
 NO_SHARED?=NO

--- a/dtc.cc
+++ b/dtc.cc
@@ -52,18 +52,18 @@ using std::string;
 /**
  * The current major version of the tool.
  */
-int version_major = 0;
-int version_major_compatible = 1;
+static int version_major = 0;
+static int version_major_compatible = 1;
 /**
  * The current minor version of the tool.
  */
-int version_minor = 5;
-int version_minor_compatible = 4;
+static int version_minor = 5;
+static int version_minor_compatible = 4;
 /**
  * The current patch level of the tool.
  */
-int version_patch = 0;
-int version_patch_compatible = 0;
+static int version_patch = 0;
+static int version_patch_compatible = 0;
 
 static void usage(const string &argv0)
 {


### PR DESCRIPTION
The only warnings that actually crop up are due to the version_* variables being local to the compilation unit and not being static (and not being declared elsewhere as 'extern').

Fix this, remove WARNS so we just catch these things as they crop up later.