### PR TITLE
Add CXXFLAGS associated with WARNS=6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.8)
 
 project(dtc)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsystem-headers -Werror -Wall -Wno-format-y2k -W -Wno-unused-parameter -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith -Wreturn-type -Wcast-qual -Wwrite-strings -Wswitch -Wshadow -Wunused-parameter -Wcast-align -Wchar-subscripts -Winline -Wnested-externs -Wredundant-decls -Wold-style-definition -Wno-pointer-sign")
+
 set(dtc_CXX_SRCS
 	checking.cc
 	dtb.cc


### PR DESCRIPTION
Trying to wrap the super-long string is a no-start, and breaking it down into separate set()'s yields 8+ lines of set() and it's even more irritating... open to ideas.