### PR TITLE
Extend node::visit to include parent node and allow control of recursion

### DIFF
--- a/fdt.hh
+++ b/fdt.hh
@@ -421,6 +421,15 @@ class node
 	 * Iterator type for child nodes.
 	 */
 	typedef std::vector<node_ptr>::iterator child_iterator;
+	/**
+	 * Recursion behavior to be observed for visiting
+	 */
+	enum visit_behavior
+	{
+		VISIT_RECURSE,
+		VISIT_CONTINUE,
+		VISIT_BREAK
+	};
 	private:
 	/**
 	 * Adaptor to use children in range-based for loops.
@@ -636,11 +645,12 @@ class node
 	void write_dts(FILE *file, int indent);
 	/**
 	 * Recursively visit this node and then its children based on the
-	 * callable's return value.  The callable returning true will cause
-	 * visit to proceed with the recursion, while returning false will halt
-	 * before recursing.  parent will be passed to the callable.
+	 * callable's return value.  The callable may return VISIT_BREAK
+	 * immediately halt all recursion and end the visit, VISIT_CONTINUE to
+	 * not recurse into the current node's children, or VISIT_RECURSE to recurse
+	 * through children as expected.  parent will be passed to the callable.
 	 */
-	void visit(std::function<bool(node&, node*)>, node *parent);
+	visit_behavior visit(std::function<visit_behavior(node&, node*)>, node *parent);
 };
 
 /**

--- a/fdt.hh
+++ b/fdt.hh
@@ -635,9 +635,12 @@ class node
 	 */
 	void write_dts(FILE *file, int indent);
 	/**
-	 * Recursively visit this node and then its children.
+	 * Recursively visit this node and then its children based on the
+	 * callable's return value.  The callable returning true will cause
+	 * visit to proceed with the recursion, while returning false will halt
+	 * before recursing.  parent will be passed to the callable.
 	 */
-	void visit(std::function<void(node&)>);
+	void visit(std::function<bool(node&, node*)>, node *parent);
 };
 
 /**


### PR DESCRIPTION
The callable's return value may indicate whether the recursion should happen or
not. `parent` as passed to `visit` will be passed on to the callable, and the
recursive call will pass the current node as the parent to its children.

I've submitted this separately from /delete-if-unreferenced/ since it's worth of review on its own.