### PR TITLE
Add path-based syntactic sugar

### DIFF
--- a/Tests/overlay_sugar.at.dts
+++ b/Tests/overlay_sugar.at.dts
@@ -24,3 +24,15 @@
 		foobar,status = "okay";
 	};
 };
+
+&{/} {
+	foobar {
+		foobar,status = "okay";
+	};
+};
+
+&{/soc} {
+	quux: baz {
+		baz,status = "okay";
+	};
+};

--- a/Tests/overlay_sugar.at.dts.expected
+++ b/Tests/overlay_sugar.at.dts.expected
@@ -39,8 +39,32 @@
 			};
 		};
 	};
+	fragment@4 {
+
+		target-path = "/";
+		__overlay__ {
+
+			foobar {
+
+				foobar,status = "okay";
+			};
+		};
+	};
+	fragment@5 {
+
+		target-path = "/soc";
+		__overlay__ {
+
+			baz {
+
+				baz,status = "okay";
+				phandle = <0x2>;
+			};
+		};
+	};
 	__symbols__ {
 
+		quux = "/fragment@5/__overlay__/baz";
 		foobar = "/fragment@3/__overlay__/foobar";
 	};
 	__fixups__ {

--- a/dtc.1
+++ b/dtc.1
@@ -30,7 +30,7 @@
 .\"
 .\" $FreeBSD$
 .\"/
-.Dd January 17, 2018
+.Dd April 7, 2018
 .Dt DTC 1
 .Os
 .Sh NAME
@@ -275,7 +275,7 @@ tree when the overlay is applied.
 .Pp
 Much simpler syntactic sugar was later invented to simplify generating overlays.
 Instead of creating targetted fragments manually, one can instead create a root
-node that targets a label in the base node using the
+node that targets a label in the base FDT using the
 .Va &label
 syntax supported in conventional DTS.
 This will indicate that a fragment should be generated for the node, with the
@@ -283,6 +283,19 @@ given
 .Va label
 being the target, and the properties and child nodes will be used as the
 __overlay__.
+.Pp
+Additionally, a path-based version of this syntactic sugar is supported.
+A root node may target a path in the base FDT using a name of the form
+.Va &{/path} .
+A fragment will be generated for the node as it is in the
+.Va &label
+case, except the
+.Va target-path
+property will be set to
+.Va /path
+and no
+.Va target
+will be set.
 .Pp
 Both conventional overlays and the later-added syntactic sugar are supported.
 .Pp

--- a/fdt.hh
+++ b/fdt.hh
@@ -409,6 +409,10 @@ class node
 	 */
 	std::string name;
 	/**
+	 * The name of the node is a path reference.
+	 */
+	bool name_is_path_reference = false;
+	/**
 	 * The unit address of the node, which is optionally written after the
 	 * name followed by an at symbol.
 	 */


### PR DESCRIPTION
This syntax was added to GPL dtc in this commit: https://github.com/dgibson/dtc/commit/8f1b35f88395adea01ce1100c5faa27dacbc8410

Add the equivalent to our dtc, so that the following overlay:

```
/dts-v1/;
/plugin/;

&{/soc} {
    foo = "bar";
};
```
will effectively be turned into the following:
```
/dts-v1/;
/plugin/;

/ {
    fragment@0 {
        target-path = "/soc";
        __overlay__ {
            foo = "bar";
        };
    };
};
```