### PR TITLE
Split out consumption of magic number from magic number check

### DIFF
--- a/dtb.cc
+++ b/dtb.cc
@@ -262,9 +262,14 @@ header::write(output_writer &out)
 bool
 header::read_dtb(input_buffer &input)
 {
-	if (!(input.consume_binary(magic) && magic == 0xd00dfeed))
+	if (!input.consume_binary(magic))
 	{
-		fprintf(stderr, "Missing magic token in header.  Got %" PRIx32
+		fprintf(stderr, "Missing magic token in header.");
+		return false;
+	}
+	if (magic != 0xd00dfeed)
+	{
+		fprintf(stderr, "Bad magic token in header.  Got %" PRIx32
 		                " expected 0xd00dfeed\n", magic);
 		return false;
 	}


### PR DESCRIPTION
If consumption fails, we cannot trust that 'magic' was populated with
anything useful.  To compound on this, 'magic' is initialized with
0xd00dfeed.  These facts combined meant that piping completely broken or
missing output into dtc would always result in an error message like:

Missing magic token in header.  Got d00dfeed expected 0xd00dfeed

Which is wrong, since it most certainly did not get d00dfeed. Instead of
removing the initialization, just split it out so we have two obviously
different error cases: Missing magic token, and incorrect magic token.