### PR TITLE
 Fix compilation of overlays without -@

### DIFF
--- a/Tests/overlay_nosym.dts
+++ b/Tests/overlay_nosym.dts
@@ -1,0 +1,42 @@
+/dts-v1/;
+/plugin/;
+
+&foo {
+	foo,status = "okay";
+};
+
+&bar {
+	bar,status = "okay";
+};
+
+/ {
+	fragment@0 {
+		target = <&qux>;
+		__overlay__ {
+			qux,status = "okay";
+		};
+	};
+};
+
+&baz {
+	baz,status = "okay";
+	foobar: foobar {
+		foobar,status = "okay";
+	};
+};
+
+&{/} {
+	foobar {
+		foobar,status = "okay";
+	};
+};
+
+&{/soc} {
+	quux: baz {
+		baz,status = "okay";
+	};
+};
+
+&{/soc/ethernet@1000} {
+	quuxnode = <&quux>;
+};

--- a/Tests/overlay_nosym.dts.expected
+++ b/Tests/overlay_nosym.dts.expected
@@ -1,0 +1,89 @@
+/dts-v1/;
+
+/  {
+
+	fragment@0 {
+
+		target = <0xdeadbeef>;
+		__overlay__ {
+
+			foo,status = "okay";
+		};
+	};
+	fragment@1 {
+
+		target = <0xdeadbeef>;
+		__overlay__ {
+
+			bar,status = "okay";
+		};
+	};
+	fragment@2 {
+
+		target = <0xdeadbeef>;
+		__overlay__ {
+
+			qux,status = "okay";
+		};
+	};
+	fragment@3 {
+
+		target = <0xdeadbeef>;
+		__overlay__ {
+
+			baz,status = "okay";
+			foobar {
+
+				foobar,status = "okay";
+			};
+		};
+	};
+	fragment@4 {
+
+		target-path = "/";
+		__overlay__ {
+
+			foobar {
+
+				foobar,status = "okay";
+			};
+		};
+	};
+	fragment@5 {
+
+		target-path = "/soc";
+		__overlay__ {
+
+			baz {
+
+				baz,status = "okay";
+				phandle = <0x1>;
+			};
+		};
+	};
+	fragment@6 {
+
+		target-path = "/soc/ethernet@1000";
+		__overlay__ {
+
+			quuxnode = <0x1>;
+		};
+	};
+	__fixups__ {
+
+		foo = "/fragment@0:target:0";
+		bar = "/fragment@1:target:0";
+		qux = "/fragment@2:target:0";
+		baz = "/fragment@3:target:0";
+	};
+	__local_fixups__ {
+
+		fragment@6 {
+
+			__overlay__ {
+
+				quuxnode = <0x0>;
+			};
+		};
+	};
+};

--- a/fdt.cc
+++ b/fdt.cc
@@ -1917,80 +1917,74 @@ device_tree::parse_dts(const string &fn, FILE *depfile)
 			symbols.push_back(prop);
 		}
 		root->add_child(node::create_special_node("__symbols__", symbols));
-		// If this is a plugin, then we also need to create two extra nodes.
-		// Internal phandles will need to be renumbered to avoid conflicts with
-		// already-loaded nodes and external references will need to be
-		// resolved.
-		if (is_plugin)
+	}
+	// If this is a plugin, then we also need to create two extra nodes.
+	// Internal phandles will need to be renumbered to avoid conflicts with
+	// already-loaded nodes and external references will need to be
+	// resolved.
+	if (is_plugin)
+	{
+		std::vector<property_ptr> symbols;
+		// Create the fixups entry.  This is of the form:
+		// {target} = {path}:{property name}:{offset}
+		auto create_fixup_entry = [&](fixup &i, string target)
+			{
+				string value = i.path.to_string();
+				value += ':';
+				value += i.prop->get_key();
+				value += ':';
+				value += std::to_string(i.prop->offset_of_value(i.val));
+				property_value v;
+				v.string_data = value;
+				v.type = property_value::STRING;
+				auto prop = std::make_shared<property>(std::move(target));
+				prop->add_value(v);
+				return prop;
+			};
+		// If we have any unresolved phandle references in this plugin,
+		// then we must update them to 0xdeadbeef and leave a property in
+		// the /__fixups__ node whose key is the label and whose value is
+		// as described above.
+		if (!unresolved_fixups.empty())
 		{
-			// Create the fixups entry.  This is of the form:
-			// {target} = {path}:{property name}:{offset}
-			auto create_fixup_entry = [&](fixup &i, string target)
-				{
-					string value = i.path.to_string();
-					value += ':';
-					value += i.prop->get_key();
-					value += ':';
-					value += std::to_string(i.prop->offset_of_value(i.val));
-					property_value v;
-					v.string_data = value;
-					v.type = property_value::STRING;
-					auto prop = std::make_shared<property>(std::move(target));
-					prop->add_value(v);
-					return prop;
-				};
-			// If we have any unresolved phandle references in this plugin,
-			// then we must update them to 0xdeadbeef and leave a property in
-			// the /__fixups__ node whose key is the label and whose value is
-			// as described above.
-			if (!unresolved_fixups.empty())
+			for (auto &i : unresolved_fixups)
 			{
-				symbols.clear();
-				for (auto &i : unresolved_fixups)
-				{
-					auto &val = i.get().val;
-					symbols.push_back(create_fixup_entry(i, val.string_data));
-					val.byte_data.push_back(0xde);
-					val.byte_data.push_back(0xad);
-					val.byte_data.push_back(0xbe);
-					val.byte_data.push_back(0xef);
-					val.type = property_value::BINARY;
-				}
-				root->add_child(node::create_special_node("__fixups__", symbols));
+				auto &val = i.get().val;
+				symbols.push_back(create_fixup_entry(i, val.string_data));
+				val.byte_data.push_back(0xde);
+				val.byte_data.push_back(0xad);
+				val.byte_data.push_back(0xbe);
+				val.byte_data.push_back(0xef);
+				val.type = property_value::BINARY;
 			}
-			symbols.clear();
-			// If we have any resolved phandle references in this plugin, then
-			// we must create a child in the __local_fixups__ node whose path
-			// matches the node path from the root and whose value contains the
-			// location of the reference within a property.
-			
-			// Create a local_fixups node that is initially empty.
-			node_ptr local_fixups = node::create_special_node("__local_fixups__", symbols);
-			for (auto &i : fixups)
+			root->add_child(node::create_special_node("__fixups__", symbols));
+		}
+		symbols.clear();
+		// If we have any resolved phandle references in this plugin, then
+		// we must create a child in the __local_fixups__ node whose path
+		// matches the node path from the root and whose value contains the
+		// location of the reference within a property.
+		
+		// Create a local_fixups node that is initially empty.
+		node_ptr local_fixups = node::create_special_node("__local_fixups__", symbols);
+		for (auto &i : fixups)
+		{
+			if (!i.val.is_phandle())
 			{
-				if (!i.val.is_phandle())
+				continue;
+			}
+			node *n = local_fixups.get();
+			for (auto &p : i.path)
+			{
+				// Skip the implicit root
+				if (p.first.empty())
 				{
 					continue;
 				}
-				node *n = local_fixups.get();
-				for (auto &p : i.path)
+				bool found = false;
+				for (auto &c : n->child_nodes())
 				{
-					// Skip the implicit root
-					if (p.first.empty())
-					{
-						continue;
-					}
-					bool found = false;
-					for (auto &c : n->child_nodes())
-					{
-						if (c->name == p.first)
-						{
-							n = c.get();
-							found = true;
-							break;
-						}
-					}
-					if (!found)
+					if (c->name == p.first)
 					{
 						string path = p.first;
 						if (!(p.second.empty()))
@@ -2002,37 +1996,42 @@ device_tree::parse_dts(const string &fn, FILE *depfile)
 						n = (--n->child_end())->get();
 					}
 				}
-				assert(n);
-				property_value pv;
-				push_big_endian(pv.byte_data, static_cast<uint32_t>(i.prop->offset_of_value(i.val)));
-				pv.type = property_value::BINARY;
-				auto key = i.prop->get_key();
-				property_ptr prop = n->get_property(key);
-				// If we don't have an existing property then create one and
-				// use this property value
-				if (!prop)
+				if (!found)
 				{
-					prop = std::make_shared<property>(std::move(key));
-					n->add_property(prop);
+					n->add_child(node::create_special_node(p.first, symbols));
+					n = (--n->child_end())->get();
+				}
+			}
+			assert(n);
+			property_value pv;
+			push_big_endian(pv.byte_data, static_cast<uint32_t>(i.prop->offset_of_value(i.val)));
+			pv.type = property_value::BINARY;
+			auto key = i.prop->get_key();
+			property_ptr prop = n->get_property(key);
+			// If we don't have an existing property then create one and
+			// use this property value
+			if (!prop)
+			{
+				prop = std::make_shared<property>(std::move(key));
+				n->add_property(prop);
+				prop->add_value(pv);
+			}
+			else
+			{
+				// If we do have an existing property value, try to append
+				// this value.
+				property_value &old_val = *(--prop->end());
+				if (!old_val.try_to_merge(pv))
+				{
 					prop->add_value(pv);
 				}
-				else
-				{
-					// If we do have an existing property value, try to append
-					// this value.
-					property_value &old_val = *(--prop->end());
-					if (!old_val.try_to_merge(pv))
-					{
-						prop->add_value(pv);
-					}
-				}
 			}
-			// We've iterated over all fixups, but only emit the
-			// __local_fixups__ if we found some that were resolved internally.
-			if (local_fixups->child_begin() != local_fixups->child_end())
-			{
-				root->add_child(std::move(local_fixups));
-			}
+		}
+		// We've iterated over all fixups, but only emit the
+		// __local_fixups__ if we found some that were resolved internally.
+		if (local_fixups->child_begin() != local_fixups->child_end())
+		{
+			root->add_child(std::move(local_fixups));
 		}
 	}
 }


### PR DESCRIPTION
All of the /__fixups__ and /__local_fixups__ generation was gated by -@.
This is not a strict requirement for overlays, though, and it works fine
with GPL dtc.

A test case has been added for this case.