### PR TITLE
Fix __local_fixup__ pathes with unit number in the name

### DIFF
--- a/Tests/localfixups_fragment_unit.at.dts
+++ b/Tests/localfixups_fragment_unit.at.dts
@@ -1,0 +1,19 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+    fragment@1 {
+        target = <&foo>;
+        __overlay__ {
+            f1_label: f1_node {
+            };
+        };
+    };
+
+    fragment@2 {
+        target = <&bar>;
+        __overlay__ {
+            ref-0 = <&f1_label>;
+        };
+    };
+};

--- a/Tests/localfixups_fragment_unit.at.dts.expected
+++ b/Tests/localfixups_fragment_unit.at.dts.expected
@@ -1,0 +1,43 @@
+/dts-v1/;
+
+/  {
+
+	fragment@1 {
+
+		target = <0xdeadbeef>;
+		__overlay__ {
+
+			f1_node {
+
+				phandle = <0x1>;
+			};
+		};
+	};
+	fragment@2 {
+
+		target = <0xdeadbeef>;
+		__overlay__ {
+
+			ref-0 = <0x1>;
+		};
+	};
+	__symbols__ {
+
+		f1_label = "/fragment@1/__overlay__/f1_node";
+	};
+	__fixups__ {
+
+		foo = "/fragment@1:target:0";
+		bar = "/fragment@2:target:0";
+	};
+	__local_fixups__ {
+
+		fragment@2 {
+
+			__overlay__ {
+
+				ref-0 = <0x0>;
+			};
+		};
+	};
+};

--- a/fdt.cc
+++ b/fdt.cc
@@ -1992,7 +1992,13 @@ device_tree::parse_dts(const string &fn, FILE *depfile)
 					}
 					if (!found)
 					{
-						n->add_child(node::create_special_node(p.first, symbols));
+						string path = p.first;
+						if (!(p.second.empty()))
+						{
+							path += '@';
+							path += p.second;
+						}
+						n->add_child(node::create_special_node(path, symbols));
 						n = (--n->child_end())->get();
 					}
 				}


### PR DESCRIPTION
Do not omit unit number when generating __local_fixups__ entries
in overlay, the name in the section should match the name of the
node to fix up exactly