### PR TITLE
Don't depend on implicit header dependencies

### DIFF
--- a/string.cc
+++ b/string.cc
@@ -36,6 +36,7 @@
 #include <functional>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <ctype.h>
 #include <libgen.h>
 

--- a/util.hh
+++ b/util.hh
@@ -35,6 +35,9 @@
 #ifndef _UTIL_HH_
 #define _UTIL_HH_
 
+#include <memory>
+#include <stdint.h>
+#include <string>
 #include <vector>
 
 // If we aren't using C++11, then just ignore static asserts.


### PR DESCRIPTION
When building against libstdc++ these headers aren't pulled in implicitly