### PR TITLE
Some cleanup from /omit-if-no-ref/

### DIFF
--- a/fdt.cc
+++ b/fdt.cc
@@ -919,7 +919,7 @@ node::node(text_input_buffer &input,
 		{
 			input.next_token();
 			omit_if_no_ref = true;
-			tree.needs_garbage_collection();
+			tree.set_needs_garbage_collection();
 		}
 		child_name = parse_name(input, is_property,
 				"Expected property or node name");

--- a/fdt.hh
+++ b/fdt.hh
@@ -56,6 +56,7 @@ namespace fdt
 {
 class property;
 class node;
+class device_tree;
 /**
  * Type for (owned) pointers to properties.
  */
@@ -523,6 +524,7 @@ class node
 	 * already been parsed.
 	 */
 	node(text_input_buffer &input,
+	     device_tree &tree,
 	     std::string &&n,
 	     std::unordered_set<std::string> &&l,
 	     std::string &&a,
@@ -619,6 +621,7 @@ class node
 	 * have been parsed.
 	 */
 	static node_ptr parse(text_input_buffer &input,
+	                      device_tree &tree,
 	                      std::string &&name,
 	                      std::unordered_set<std::string> &&label=std::unordered_set<std::string>(),
 	                      std::string &&address=std::string(),
@@ -732,6 +735,11 @@ class device_tree
 	 * on parse errors. 
 	 */
 	bool valid = true;
+	/**
+	 * Flag indicating that this tree requires garbage collection.  This will be
+	 * set to true if a node marked /omit-if-no-ref/ is encountered.
+	 */
+	bool garbage_collect = false;
 	/**
 	 * Type used for memory reservations.  A reservation is two 64-bit
 	 * values indicating a base address and length in memory that the
@@ -970,6 +978,14 @@ class device_tree
 	inline bool is_valid()
 	{
 		return valid;
+	}
+	/**
+	 * Mark this tree as needing garbage collection, because an /omit-if-no-ref/
+	 * node has been encountered.
+	 */
+	void needs_garbage_collection()
+	{
+		garbage_collect = true;
 	}
 	/**
 	 * Sets the format for writing phandle properties.

--- a/fdt.hh
+++ b/fdt.hh
@@ -417,8 +417,18 @@ class node
 	 * name followed by an at symbol.
 	 */
 	std::string unit_address;
-	struct node_flag_bits {
+	struct node_flag_bits
+	{
+		/**
+		 * A flag indicating that this node has been marked /omit-if-no-ref/ and
+		 * will be omitted if it is not referenced, either directly or indirectly,
+		 * by a node that is not similarly denoted.
+		 */
 		char omit_if_no_ref : 1;
+		/**
+		 * A flag indicating that this node has been referenced, either directly
+		 * or indirectly, by a node that is not marked /omit-if-no-ref/.
+		 */
 		char used : 1;
 
 		node_flag_bits() : omit_if_no_ref(0), used(0) {};
@@ -870,6 +880,14 @@ class device_tree
 	 * marked for "delete if unreferenced" will also occur here.
 	 */
 	void resolve_cross_references(uint32_t &phandle);
+	/**
+	 * Garbage collects nodes that have been marked /omit-if-no-ref/ and do not
+	 * have any references to them from nodes that are similarly marked.  This
+	 * is a fairly expensive operation.  The return value indicates whether the
+	 * tree has been dirtied as a result of this operation, so that the caller
+	 * may take appropriate measures to bring the device tree into a consistent
+	 * state as needed.
+	 */
 	bool garbage_collect_marked_nodes();
 	/**
 	 * Parses a dts file in the given buffer and adds the roots to the parsed

--- a/fdt.hh
+++ b/fdt.hh
@@ -983,7 +983,7 @@ class device_tree
 	 * Mark this tree as needing garbage collection, because an /omit-if-no-ref/
 	 * node has been encountered.
 	 */
-	void needs_garbage_collection()
+	void set_needs_garbage_collection()
 	{
 		garbage_collect = true;
 	}

--- a/fdt.hh
+++ b/fdt.hh
@@ -418,22 +418,17 @@ class node
 	 * name followed by an at symbol.
 	 */
 	std::string unit_address;
-	struct node_flag_bits
-	{
-		/**
-		 * A flag indicating that this node has been marked /omit-if-no-ref/ and
-		 * will be omitted if it is not referenced, either directly or indirectly,
-		 * by a node that is not similarly denoted.
-		 */
-		char omit_if_no_ref : 1;
-		/**
-		 * A flag indicating that this node has been referenced, either directly
-		 * or indirectly, by a node that is not marked /omit-if-no-ref/.
-		 */
-		char used : 1;
-
-		node_flag_bits() : omit_if_no_ref(0), used(0) {};
-	} node_flags;
+	/**
+	 * A flag indicating that this node has been marked /omit-if-no-ref/ and
+	 * will be omitted if it is not referenced, either directly or indirectly,
+	 * by a node that is not similarly denoted.
+	 */
+	bool omit_if_no_ref = false;
+	/**
+	 * A flag indicating that this node has been referenced, either directly
+	 * or indirectly, by a node that is not marked /omit-if-no-ref/.
+	 */
+	bool used = false;
 	/**
 	 * The type for the property vector.
 	 */


### PR DESCRIPTION
As requested by David:
- Documentation for several fields and methods added
- A flag for the device_tree having encountered an /omit-if-no-ref/ has been added to avoid the extra expense

I'm still working through the details of how to tell that a node's being kept alive because of one of its descendants. The two approaches I see at the moment of determining the node's heritage are either a tree walk for each of the nodes we're marking as 'seen' (incredibly not ideal), or storing the path to each node in the tree for comparisons' sake. The latter seems like a more viable option. I'd also need to change the 'used' tracking into more of a ref-count rather than the current single-bit so we can check `used == 1 && used_by_descendant`, but that's not much of an issue.