### PR TITLE
Fix segfault when errors happen while compiling a path-ref node

### DIFF
--- a/fdt.cc
+++ b/fdt.cc
@@ -1622,7 +1622,10 @@ device_tree::parse_file(text_input_buffer &input,
 			}
 			input.next_token();
 			n = node::parse(input, *this, std::move(name), string_set(), string(), &defines);
-			n->name_is_path_reference = name_is_path_reference;
+			if (n)
+			{
+				n->name_is_path_reference = name_is_path_reference;
+			}
 		}
 		else
 		{


### PR DESCRIPTION
node::parse will return 0 instead of a valid pointer if the node it parsed was
ultimately not valid.  This bit failed to check for that.