### PR TITLE
Collection of fixes for /memreserve/ handling

### DIFF
--- a/Tests/memreserve.dts
+++ b/Tests/memreserve.dts
@@ -1,0 +1,7 @@
+/dts-v1/;
+
+/memreserve/ 0x0 0x1000;
+
+/ {
+	compatible = "memreserve";
+};

--- a/Tests/memreserve.dts.expected
+++ b/Tests/memreserve.dts.expected
@@ -1,0 +1,8 @@
+/dts-v1/;
+
+/memreserve/ 0x0 0x1000;
+
+/  {
+
+	compatible = "memreserve";
+};

--- a/fdt.cc
+++ b/fdt.cc
@@ -1664,7 +1664,7 @@ device_tree::write(int fd)
 		reservation_writer.write_comment(string("Reservation start"));
 		reservation_writer.write_data(i.first);
 		reservation_writer.write_comment(string("Reservation length"));
-		reservation_writer.write_data(i.first);
+		reservation_writer.write_data(i.second);
 	}
 	// Write n spare reserve map entries, plus the trailing 0.
 	for (uint32_t i=0 ; i<=spare_reserve_map_entries ; i++)

--- a/fdt.cc
+++ b/fdt.cc
@@ -1589,9 +1589,12 @@ device_tree::parse_file(text_input_buffer &input,
 		{
 			input.parse_error("Expected size on /memreserve/ node.");
 		}
+		else
+		{
+			reservations.push_back(reservation(start, len));
+		}
 		input.next_token();
 		input.consume(';');
-		reservations.push_back(reservation(start, len));
 		input.next_token();
 	}
 	while (valid && !input.finished())

--- a/fdt.cc
+++ b/fdt.cc
@@ -1795,6 +1795,10 @@ device_tree::parse_dtb(const string &fn, FILE *)
 			valid = false;
 			return;
 		}
+		if (start != 0 || length != 0)
+		{
+			reservations.push_back(reservation(start, length));
+		}
 	} while (!((start == 0) && (length == 0)));
 	input_buffer struct_table =
 		input.buffer_from_offset(h.off_dt_struct, h.size_dt_struct);

--- a/fdt.cc
+++ b/fdt.cc
@@ -1754,7 +1754,7 @@ device_tree::write_dts(int fd)
 		fwrite(msg, sizeof(msg) - 1, 1, file);
 		for (auto &i : reservations)
 		{
-			fprintf(file, " %" PRIx64 " %" PRIx64, i.first, i.second);
+			fprintf(file, " 0x%" PRIx64 " 0x%" PRIx64, i.first, i.second);
 		}
 		fputs(";\n\n", file);
 	}

--- a/fdt.cc
+++ b/fdt.cc
@@ -1747,7 +1747,8 @@ device_tree::write_dts(int fd)
 	if (!reservations.empty())
 	{
 		const char msg[] = "/memreserve/";
-		fwrite(msg, sizeof(msg), 1, file);
+		// Exclude the null byte when we're writing it out to the file.
+		fwrite(msg, sizeof(msg) - 1, 1, file);
 		for (auto &i : reservations)
 		{
 			fprintf(file, " %" PRIx64 " %" PRIx64, i.first, i.second);


### PR DESCRIPTION
Testing and attempting to use dtc to parse out /memreserve/ nodes in the RPi DTB yielded a somewhat major issue in our dtc- there were no /memreserve/ in the output! This series fixes that and a couple of other issues with the handling; the commit messages describe the various issues I ran into.