### PR TITLE
dtc: assume proper -I/-O formats if only one is specified

### DIFF
--- a/dtc.cc
+++ b/dtc.cc
@@ -94,6 +94,8 @@ void version(const char* progname)
 } // Anonymous namespace
 
 using fdt::device_tree;
+using fdt::tree_write_fn_ptr;
+using fdt::tree_read_fn_ptr;
 
 int
 main(int argc, char **argv)
@@ -104,8 +106,8 @@ main(int argc, char **argv)
 	const char *in_file = "-";
 	FILE *depfile = 0;
 	bool debug_mode = false;
-	auto write_fn = &device_tree::write_binary;
-	auto read_fn = &device_tree::parse_dts;
+	tree_write_fn_ptr write_fn = nullptr;
+	tree_read_fn_ptr read_fn = nullptr;
 	uint32_t boot_cpu = 0;
 	bool boot_cpu_specified = false;
 	bool keep_going = false;
@@ -135,6 +137,10 @@ main(int argc, char **argv)
 			if (arg == "dtb")
 			{
 				read_fn = &device_tree::parse_dtb;
+				if (write_fn == nullptr)
+				{
+					write_fn = &device_tree::write_dts;
+				}
 			}
 			else if (arg == "dts")
 			{
@@ -161,6 +167,10 @@ main(int argc, char **argv)
 			else if (arg == "dts")
 			{
 				write_fn = &device_tree::write_dts;
+				if (read_fn == nullptr)
+				{
+					read_fn = &device_tree::parse_dtb;
+				}
 			}
 			else
 			{
@@ -297,6 +307,14 @@ main(int argc, char **argv)
 			fprintf(stderr, "Unknown option %c\n", ch);
 			return EXIT_FAILURE;
 		}
+	}
+	if (read_fn == nullptr)
+	{
+		read_fn = &device_tree::parse_dts;
+	}
+	if (write_fn == nullptr)
+	{
+		write_fn = &device_tree::write_binary;
 	}
 	if (optind < argc)
 	{

--- a/fdt.hh
+++ b/fdt.hh
@@ -59,6 +59,14 @@ class property;
 class node;
 class device_tree;
 /**
+ * Type for device tree write functions.
+ */
+typedef void (device_tree::* tree_write_fn_ptr)(int);
+/**
+ * Type for device tree read functions.
+ */
+typedef void (device_tree::* tree_read_fn_ptr)(const std::string &, FILE *);
+/**
  * Type for (owned) pointers to properties.
  */
 typedef std::shared_ptr<property> property_ptr;


### PR DESCRIPTION
This matches the behavior of GPL dtc; for instance, if -I dts is specified,
then -O dtb is assumed. -I dtb assumes -O dts, and all of this works in
reverse as well if just -O is specified.

We still default to -I dts -O dtb if both are omitted or -I dts if -O asm is
specified.

Signed-off-by: Kyle Evans <kevans@FreeBSD.org>