### PR TITLE
exit requires stdlib.h to be included for use

### DIFF
--- a/dtb.cc
+++ b/dtb.cc
@@ -36,6 +36,7 @@
 #include <sys/types.h>
 #include <inttypes.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <errno.h>
 


### PR DESCRIPTION
FreeBSD 10.3 requires this, and dtc is a bootstrap tool so it needs to
compile there.

This is FreeBSD r353961