### PR TITLE
dtc: remove unknown option printf, since getopt will print it

### DIFF
--- a/dtc.cc
+++ b/dtc.cc
@@ -304,7 +304,10 @@ main(int argc, char **argv)
 			}
 			break;
 		default:
-			fprintf(stderr, "Unknown option %c\n", ch);
+			/* 
+			 * Since opterr is non-zero, getopt will have
+			 * already printed an error message.
+			 */
 			return EXIT_FAILURE;
 		}
 	}


### PR DESCRIPTION
Since we don't set opterr to 0, getopt prints a message when it
encounters an unknown/invalid option. We therefore don't need to
print our own message in the default handler.