### PR TITLE
Sync Makefile(.depend) with FreeBSD versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,11 @@ PROG_CXX=dtc
 SRCS=	dtc.cc input_buffer.cc string.cc dtb.cc fdt.cc checking.cc
 MAN=	dtc.1
 
-CXXFLAGS+=	-std=c++11 -fno-rtti -fno-exceptions
+WARNS?=	3
+
+CXXFLAGS+=	-fno-rtti -fno-exceptions
+
+CXXSTD=	c++11
 
 NO_SHARED?=NO
 

--- a/Makefile.depend
+++ b/Makefile.depend
@@ -3,7 +3,6 @@
 
 DIRDEPS = \
 	gnu/lib/csu \
-	gnu/lib/libgcc \
 	include \
 	include/xlocale \
 	lib/${CSU_DIR} \


### PR DESCRIPTION
This is the only non-upstreamed diff left in FreeBSD across all files.