### PR TITLE
Add missing <limits> includes

### DIFF
--- a/fdt.cc
+++ b/fdt.cc
@@ -38,6 +38,7 @@
 #include "dtb.hh"
 
 #include <algorithm>
+#include <limits>
 #include <sstream>
 
 #include <ctype.h>

--- a/input_buffer.cc
+++ b/input_buffer.cc
@@ -35,11 +35,11 @@
 #include "input_buffer.hh"
 #include <ctype.h>
 #include <errno.h>
-#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits>
 #include <functional>
 #ifndef NDEBUG
 #include <iostream>


### PR DESCRIPTION
It seems that recent libstdc++ pulls in fewer headers implicitly, so this
is needed to avoid compilation errors due to missing std::numeric_limits<>.

Co-authored-by: John Baldwin <jhb@FreeBSD.org>

See https://github.com/CTSRD-CHERI/cheribsd/commit/c05532bebd36c84aeebf16b734595c5b443fbde6 and  https://github.com/CTSRD-CHERI/cheribsd/pull/1331