### PR TITLE
Remove C++11 standard constrain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ WARNS?=	3
 
 CXXFLAGS+=	-fno-rtti -fno-exceptions
 
-CXXSTD=	c++11
-
 NO_SHARED?=NO
 
 .include <bsd.prog.mk>


### PR DESCRIPTION
This was added before Clang bumped the default to C++11 and is no longer needed.

Close #74