### PR TITLE
GitHub: Update actions/checkout version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ${{ matrix.config.os }}
     name: ${{ matrix.config.name }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install ninja
       run: ${{ matrix.config.dependencies }}
     - name: Configure CMake


### PR DESCRIPTION
To avoid warnings about upgrading from a deprecated node version.

References:	https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/