### PR TITLE
Ensure that dtc is built in C++17 mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ WARNS?=	3
 
 CXXFLAGS+=	-fno-rtti -fno-exceptions
 
+CXXSTD=	c++17
+
 NO_SHARED?=NO
 
 .include <bsd.prog.mk>


### PR DESCRIPTION
This is in line with dcd8a4cd5fb509da34e287db4570b7b9a11f2d57.

Given FreeBSD does not use `CMakeLists.txt`.