### PR TITLE
Revert "Ensure that dtc is built in C++17 mode"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@ WARNS?=	3
 
 CXXFLAGS+=	-fno-rtti -fno-exceptions
 
-CXXSTD=	c++17
-
 NO_SHARED?=NO
 
 .include <bsd.prog.mk>


### PR DESCRIPTION
This reverts commit 39a58cfaab7d55c7975ebf905d859ba91a369fa0.

In order to keep it inline with FreeBSD commit
6527682ab7058e5023a2a6dea01d51c15dca701f.