### PR TITLE
Set a maximum cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0...3.5)
 
 project(dtc)
 


### PR DESCRIPTION
Compatibility with CMake < 3.5 has been removed from CMake.