### PR TITLE
Address style(9) fixes

### DIFF
--- a/input_buffer.cc
+++ b/input_buffer.cc
@@ -343,11 +343,11 @@ input_buffer::consume_char_literal(unsigned long long &outInt)
 	outInt = (unsigned char)((*this)[0]);
 	cursor++;
 
-	if(outInt != '\\')
+	if (outInt != '\\')
 	{
 		return true;
 	}
-	else if(cursor >= size)
+	else if (cursor >= size)
 	{
 		return false;
 	}
@@ -917,7 +917,7 @@ expression_ptr text_input_buffer::parse_expression(bool stopAtParen)
 	{
 		case '\'':
 			consume('\'');
-			if(!consume_char_literal(leftVal))
+			if (!consume_char_literal(leftVal))
 			{
 				return nullptr;
 			}


### PR DESCRIPTION
Address @jrtc27 style(9) suggestions.

---

A broader exercise using super-linter (and clang-format) was attempted here https://github.com/jlduran/dtc/tree/add-gh-linter however, it will not be submitted (unless explicitly requested), as there are many white space changes, and may not be fully style(9)-compliant.